### PR TITLE
Adds block style `logger.info { "foo" }`

### DIFF
--- a/spec/formatters/json_formatter_spec.cr
+++ b/spec/formatters/json_formatter_spec.cr
@@ -4,13 +4,13 @@ describe Crylog::Formatters::JsonFormatter do
   describe "#call" do
     describe "defaults" do
       it "should output a JSON string" do
-        Crylog::Formatters::JsonFormatter.new.call(create_message(message: "example message")).should match /{"message":"example message","severity":100,"channel":"test","datetime":"#{JSON_TIME_REGEX}","extra":{},"context":{}/
+        Crylog::Formatters::JsonFormatter.new.call(create_message(message: "example message", context: Crylog::LogContext{"key" => "12"}, extra: Crylog::LogContext{"key" => "value"})).should match /{"message":"example message","severity":100,"channel":"test","datetime":"#{JSON_TIME_REGEX}","extra":{"key":"value"},"context":{"key":"12"}/
       end
     end
 
     describe "pretty print" do
       it "should output a pretty JSON string" do
-        Crylog::Formatters::JsonFormatter.new(true).call(create_message(message: "example message")).should match /{\n  "message": "example message",\n  "severity": 100,\n  "channel": "test",\n  "datetime": "#{JSON_TIME_REGEX}",\n  "extra": {},\n  "context": {}\n}/
+        Crylog::Formatters::JsonFormatter.new(true).call(create_message(message: "example message", context: Crylog::LogContext{"key" => "12"}, extra: Crylog::LogContext{"key" => "value"})).should match /{\n  "message": "example message",\n  "severity": 100,\n  "channel": "test",\n  "datetime": "#{JSON_TIME_REGEX}",\n  "extra": {\n    "key": "value"\n  },\n  "context": {\n    "key": "12"\n  }\n}/
       end
     end
   end

--- a/spec/logger_spec.cr
+++ b/spec/logger_spec.cr
@@ -21,7 +21,7 @@ describe Crylog::Logger do
       logger.debug "foo"
 
       handler.messages.first.message.should eq "foo"
-      handler.messages.first.context.should eq Hash(String, Crylog::Context).new
+      handler.messages.first.context?.should be_false
     end
 
     it "should log a colorized string" do
@@ -30,7 +30,7 @@ describe Crylog::Logger do
       logger.debug "I'm red".colorize :red
 
       handler.messages.first.message.should eq "\e[31mI'm red\e[0m"
-      handler.messages.first.context.should eq Hash(String, Crylog::Context).new
+      handler.messages.first.context?.should be_false
     end
 
     it "should log nil" do
@@ -39,7 +39,7 @@ describe Crylog::Logger do
       logger.debug nil
 
       handler.messages.first.message.should eq ""
-      handler.messages.first.context.should eq Hash(String, Crylog::Context).new
+      handler.messages.first.context?.should be_false
     end
 
     it "should stringify whatever is logged" do
@@ -48,7 +48,7 @@ describe Crylog::Logger do
       logger.debug 123
 
       handler.messages.first.message.should eq "123"
-      handler.messages.first.context.should eq Hash(String, Crylog::Context).new
+      handler.messages.first.context?.should be_false
     end
 
     it "should log with context" do
@@ -56,6 +56,29 @@ describe Crylog::Logger do
       handler = Crylog::Handlers::TestHandler.new
       logger = Crylog::Logger.new("test").handlers = [handler] of Crylog::Handlers::LogHandler
       logger.debug "foo", Crylog::LogContext{"key" => "value"}
+
+      handler.messages.first.message.should eq "foo"
+      handler.messages.first.context.should eq Crylog::LogContext{"key" => "value"}
+    end
+
+    it "should log with a block" do
+      Crylog::Logger.new("test")
+      handler = Crylog::Handlers::TestHandler.new
+      logger = Crylog::Logger.new("test").handlers = [handler] of Crylog::Handlers::LogHandler
+      logger.debug { "foo" }
+      logger.debug { {"bar", nil} }
+
+      handler.messages.first.message.should eq "foo"
+      handler.messages.first.context?.should be_false
+      handler.messages.[1].message.should eq "bar"
+      handler.messages.[1].context?.should be_false
+    end
+
+    it "should log with a block and a context" do
+      Crylog::Logger.new("test")
+      handler = Crylog::Handlers::TestHandler.new
+      logger = Crylog::Logger.new("test").handlers = [handler] of Crylog::Handlers::LogHandler
+      logger.debug { {"foo", Crylog::LogContext{"key" => "value"}} }
 
       handler.messages.first.message.should eq "foo"
       handler.messages.first.context.should eq Crylog::LogContext{"key" => "value"}

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -14,5 +14,13 @@ def create_message(
   severity : Crylog::Severity = Crylog::Severity::Debug,
   extra : Hash(String, Crylog::Context) = Hash(String, Crylog::Context).new
 ) : Crylog::Message
-  Crylog::Message.new message, context, severity, "test", Time.utc, extra
+  crymsg = Crylog::Message.new severity, "test" do
+    {message, context}
+  end
+
+  extra.each do |key, val|
+    crymsg.extra[key] = val
+  end
+
+  crymsg
 end

--- a/src/crylog.cr
+++ b/src/crylog.cr
@@ -13,7 +13,7 @@ module Crylog
   alias Context = Nil | String | Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 | Float32 | Float64 | Bool | Hash(String, Crylog::Context) | Array(Crylog::Context)
 
   # :nodoc:
-  alias MsgType = {String, Crylog::LogContext?} | String
+  alias MsgType = Tuple(String, Crylog::LogContext?) | String
 
   # Convenience alias for creating `Crylog::Message#context` and `Crylog::Message#extra` hashes.
   #

--- a/src/crylog.cr
+++ b/src/crylog.cr
@@ -12,6 +12,9 @@ module Crylog
   # The possible types the value could be in `Crylog::Message#context` and `Crylog::Message#extra` hashes.
   alias Context = Nil | String | Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 | Float32 | Float64 | Bool | Hash(String, Crylog::Context) | Array(Crylog::Context)
 
+  # :nodoc:
+  alias MsgType = {String, Crylog::LogContext?} | String
+
   # Convenience alias for creating `Crylog::Message#context` and `Crylog::Message#extra` hashes.
   #
   # ```

--- a/src/formatters/line_formatter.cr
+++ b/src/formatters/line_formatter.cr
@@ -11,7 +11,7 @@ module Crylog::Formatters
     def call(message : Crylog::Message) : String
       sdatetime = message.datetime.to_rfc3339
       schannel = message.channel
-      sseverity = message.severity.upcase_to_s
+      sseverity = message.severity.to_s
       smessage = message.message? ? replace_line_breaks(message.message) : nil
       scontext = message.context? ? message.context.to_json : nil
       sextra = message.extra? ? message.extra.to_json : nil

--- a/src/formatters/line_formatter.cr
+++ b/src/formatters/line_formatter.cr
@@ -9,12 +9,20 @@ module Crylog::Formatters
 
     # Consumes a *message* and returns a formatted string representation of it.
     def call(message : Crylog::Message) : String
-      String.build do |str|
-        str << '[' << message.datetime.to_rfc3339 << ']' << ' '
-        str << message.channel << '.' << message.severity.to_s.upcase << ':' << ' '
-        str << replace_line_breaks(message.message)
-        str << ' ' << message.context.to_json unless message.context.empty?
-        str << ' ' << message.extra.to_json unless message.extra.empty?
+      sdatetime = message.datetime.to_rfc3339
+      schannel = message.channel
+      sseverity = message.severity.upcase_to_s
+      smessage = message.message? ? replace_line_breaks(message.message) : nil
+      scontext = message.context? ? message.context.to_json : nil
+      sextra = message.extra? ? message.extra.to_json : nil
+      strlen = 10 + sdatetime.bytesize + schannel.bytesize + sseverity.bytesize + (smessage.try &.bytesize || 0) + (scontext.try &.bytesize || 0) + (sextra.try &.bytesize || 0)
+
+      String.build(strlen) do |str|
+        str << '[' << sdatetime << ']' << ' '
+        str << schannel << '.' << sseverity << ':'
+        str << ' ' << smessage if smessage
+        str << ' ' << scontext if scontext
+        str << ' ' << sextra if sextra
       end
     end
 

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -34,12 +34,18 @@ module Crylog
     # Urgent alert.
     Emergency = 600
 
-    # :nodoc:
-    @@upcase_pool = Hash(Severity, String).new
-
-    # Returns memoized upcased String.  Used in Formatter.
-    def upcase_to_s
-      @@upcase_pool[self] ||= self.to_s.upcase
+    def to_s
+      case self
+      when .debug?     then "DEBUG"
+      when .info?      then "INFO"
+      when .notice?    then "NOTICE"
+      when .warning?   then "WARNING"
+      when .error?     then "ERROR"
+      when .critical?  then "CRITICAL"
+      when .alert?     then "ALERT"
+      when .emergency? then "EMERGENCY"
+      else                  raise "unknown #{super}"
+      end
     end
   end
 

--- a/src/message.cr
+++ b/src/message.cr
@@ -5,8 +5,7 @@ module Crylog
   class Message
     include JSON::Serializable
 
-    # The message that was logged.
-    getter message : String
+    @message : String?
 
     # The severity level of the logged message.
     getter severity : Severity
@@ -18,15 +17,82 @@ module Crylog
     getter datetime : Time
 
     # Any extra metadata added by a `Crylog::Processors::LogProcessor`.
-    property extra : Hash(String, Crylog::Context)
+    setter extra : Hash(String, Crylog::Context)?
 
-    # Any extra metadata added when the message was logged.
-    getter context : Hash(String, Crylog::Context)
+    @context : Hash(String, Crylog::Context)?
 
     # Represents the formatted version of this message.
     @[JSON::Field(ignore: true)]
     property formatted : String = ""
 
-    def initialize(@message : String, @context : Hash(String, Crylog::Context), @severity : Crylog::Severity, @channel : String, @datetime : Time, @extra : Hash(String, Crylog::Context)); end
+    # Lambda held for lazy message evaluation.
+    @[JSON::Field(ignore: true)]
+    @block : -> Crylog::MsgType
+
+    @[JSON::Field(ignore: true)]
+    @set_message_context = false
+
+    def initialize(@severity : Crylog::Severity, @channel : String, &block : -> Crylog::MsgType)
+      @datetime = Time.utc
+      @block = block
+    end
+
+    # The message that was logged.
+    def message : String
+      set_message_context
+      @message.not_nil!
+    end
+
+    # Any extra metadata added when the message was logged.
+    def context : Hash(String, Crylog::Context)
+      set_message_context
+      @context.not_nil!
+    end
+
+    def extra : Hash(String, Crylog::Context)
+      @extra ||= Hash(String, Crylog::Context).new
+    end
+
+    def message? : Bool
+      set_message_context
+      return false unless msg = @message
+      !msg.empty?
+    end
+
+    def context? : Bool
+      set_message_context
+      return false unless ctx = @context
+      !ctx.empty?
+    end
+
+    def extra? : Bool
+      return false unless ext = @extra
+      !ext.empty?
+    end
+
+    # Resolves the passed block setting @message and @context.
+    private def set_message_context : Nil
+      return if @set_message_context
+
+      mctx = @block.call
+      mctx = case mctx
+             when String
+               {mctx, nil}
+             when {String, nil}
+               mctx
+             when {String, Hash(String, Crylog::Context)}
+               mctx
+             else
+               raise "invalid types for #{mctx.inspect}"
+             end
+
+      @message, @context = mctx
+      @set_message_context = true
+    end
+
+    def to_json(builder : JSON::Builder)
+      set_message_context
+      super
+    end
   end
 end


### PR DESCRIPTION
Provides compatibility with other logging libraries including crystal's.
Blocks are resolved lazily when logged.

`severity.upcase.to_s` is memoized reducing object creation.

#### How this came to be
After converting a ruby program to crystal for speed I gave myself a pat on the back for reducing
the ruby runtime of ~6 seconds to crystal's ~17s with a small set of test data.  Wait, what?  The program has hundreds of `logger.debug { "foo #{heavy}" }` type statements.  On ruby they aren't evaluated unless logging is set to debug.  With Crylog there's structured logging that almost does the same thing but still has some overhead of 2 additional Hash objects.  I convert all calls to use Crylog's structured logging but that would couple the program to the Crylog implementation.  Instead I made this PR for compatibility with most other crystal/ruby logging implementations that  allows for compatibility and speed.

#### Benchmarks

"no log" means the message is below the severity threshold and discarded.
"logging" means the message is logged to an `IO`.

Benchmark results with new code using lambda's:
```
                                   no log  13.53M ( 73.93ns) (± 3.13%)    112B/op   1.01× slower
             no log, simple interpolation  13.60M ( 73.52ns) (± 0.93%)    112B/op   1.00× slower
               no log, hash interpolation  13.62M ( 73.43ns) (± 1.45%)    112B/op        fastest
 no log, simple interpolation and context  13.46M ( 74.31ns) (± 2.02%)    112B/op   1.01× slower
                                  logging 823.45k (  1.21µs) (± 1.41%)    480B/op  16.54× slower
            logging, simple interpolation 740.74k (  1.35µs) (± 1.54%)    688B/op  18.39× slower
              logging, hash interpolation 579.33k (  1.73µs) (± 3.08%)    688B/op  23.51× slower
logging, simple interpolation and context 542.78k (  1.84µs) (± 1.50%)  1.06kB/op  25.09× slower
```

Benchmark results with new code without lambda's:
```
                                   no log  11.55M ( 86.59ns) (± 1.48%)    128B/op        fastest
             no log, simple interpolation   5.64M (177.32ns) (± 2.27%)    336B/op   2.05× slower
               no log, hash interpolation   2.21M (452.95ns) (± 2.11%)    304B/op   5.23× slower
 no log, simple interpolation and context   5.49M (182.19ns) (± 4.70%)    352B/op   2.10× slower
                                  logging 816.49k (  1.22µs) (± 1.59%)    496B/op  14.14× slower
            logging, simple interpolation 747.20k (  1.34µs) (± 1.34%)    704B/op  15.46× slower
              logging, hash interpolation 579.81k (  1.72µs) (± 2.88%)    704B/op  19.92× slower
logging, simple interpolation and context 587.91k (  1.70µs) (± 1.73%)  1.09kB/op  19.64× slower
```

Benchmark results for the current Crylog without lambda's:
```
                                   no log   8.36M (119.62ns) (± 1.64%)    224B/op        fastest
             no log, simple interpolation   4.80M (208.47ns) (± 1.22%)    432B/op   1.74× slower
               no log, hash interpolation   2.06M (484.43ns) (± 1.38%)    400B/op   4.05× slower
 no log, simple interpolation and context   5.28M (189.33ns) (± 1.78%)    368B/op   1.58× slower
                                  logging 788.03k (  1.27µs) (± 1.13%)    624B/op  10.61× slower
            logging, simple interpolation 718.69k (  1.39µs) (± 1.66%)    832B/op  11.63× slower
              logging, hash interpolation 549.00k (  1.82µs) (± 1.49%)    944B/op  15.23× slower
logging, simple interpolation and context 590.12k (  1.69µs) (± 1.21%)  1.12kB/op  14.17× slower
```

Benchmark
```
Crylog.configure do |registry|
  registry.register "main" do |logger|
    logger.handlers = [
      Crylog::Handlers::IOHandler.new(File.new("/dev/null", "w"), severity: Crylog::Severity::Notice),
    ] of Crylog::Handlers::LogHandler
  end
end

  Benchmark.ips warmup: 0.2 do |bm|
    bm.report "no log" do
      logger.debug { "foo" }
    end

    bm.report "logging" do
      logger.error { "foo" }
    end

    bm.report "no log, simple interpolation" do
      logger.debug { "foo #{iter}" }
    end

    bm.report "logging, simple interpolation" do
      logger.error { "foo #{iter}" }
    end

    bm.report "no log, hash interpolation" do
      logger.debug { "foo #{hash}" }
    end

    bm.report "logging, hash interpolation" do
      logger.error { "foo #{hash}" }
    end

    bm.report "no log, simple interpolation and context" do
      logger.debug { {"foo #{iter}", context} }
    end

    bm.report "logging, simple interpolation and context" do
      logger.error { {"foo #{iter}", context} }
    end
  end
```

Benchmarks log to "/dev/null" to measure how a real program functions going through crystal's `IO` instead of using `NullHandler`.
